### PR TITLE
Use `deviceAspectRatio` variable instead of hardcoded ratio.

### DIFF
--- a/_media-queries.scss
+++ b/_media-queries.scss
@@ -224,7 +224,7 @@
   @else
   {
     @media only screen and (min-device-width: $deviceMinWidth) and (max-device-width: $deviceMaxWidth)
-    and (orientation:#{$orientation})
+    and (orientation: #{$orientation})
     {
       @content;
     }


### PR DESCRIPTION
Hey there,

just a quick fix to use `deviceAspectRatio` variable instead of hardcoded ratio and some minor formatting.

Thanks for library.
